### PR TITLE
:bug: Show blackhole for learner grade only.

### DIFF
--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -6,7 +6,7 @@
 /*   By: jaeskim <jaeskim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/22 18:41:01 by jaeskim           #+#    #+#             */
-/*   Updated: 2021/01/04 15:33:34 by jaeskim          ###   ########.fr       */
+/*   Updated: 2021/03/21 00:54:42 by aabajyan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,7 +100,7 @@ const Stats: React.FC<Props> = ({ data, color, cover, darkmode, logo }) => {
       </FlexContainer>
       <FlexContainer width={width}>
         <Information name={data.name} grade={data.grade} email={data.email} />
-        <Blackhole darkmode={darkmode} data={data.blackhole} />
+        { data.grade === "Learner" && <Blackhole darkmode={darkmode} data={data.blackhole} /> }
       </FlexContainer>
       <FlexContainer width={width}>
         <Level darkmode={darkmode} level={data.level} color={color} />


### PR DESCRIPTION
Closes #48. As described on this issue, blackhole should only be visible if you have a learner grade. Works fine for me. Let me know if there's any issue regarding this PR :)

![case](https://i.imgur.com/VFq85YF.png)
![case 2](https://i.imgur.com/WLHlDVR.png)
![case 3](https://i.imgur.com/ah2fqo6.png)