### PR TITLE
Poor contrast between bg and text when coalition color is light.

### DIFF
--- a/components/badge/Stats/Header.tsx
+++ b/components/badge/Stats/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 export type HeaderProps = {
+  fg: string;
   color: string;
   login: string;
   campus: string;
@@ -8,7 +9,7 @@ export type HeaderProps = {
   logo_url: string;
 };
 
-const Header = ({ color, login, campus, cursus, logo_url }: HeaderProps) => {
+const Header = ({ fg, color, login, campus, cursus, logo_url }: HeaderProps) => {
   return (
     <>
       <g id="logo" className="fadeIn">
@@ -30,7 +31,7 @@ const Header = ({ color, login, campus, cursus, logo_url }: HeaderProps) => {
         }}
       >
         <text
-          fill="white"
+          fill={fg}
           xmlSpace="preserve"
           style={{
             whiteSpace: "nowrap",
@@ -53,7 +54,7 @@ const Header = ({ color, login, campus, cursus, logo_url }: HeaderProps) => {
         }}
       >
         <text
-          fill="white"
+          fill={fg}
           xmlSpace="preserve"
           style={{
             whiteSpace: "nowrap",
@@ -76,14 +77,14 @@ const Header = ({ color, login, campus, cursus, logo_url }: HeaderProps) => {
       >
         <path
           d="M442 38.7359H457.473V46.4891H465.194V32.4781H449.748L465.194 17H457.473L442 32.4781V38.7359Z"
-          fill="white"
+          fill={fg}
         />
-        <path d="M468.527 24.7484L476.252 17H468.527V24.7484Z" fill="white" />
+        <path d="M468.527 24.7484L476.252 17H468.527V24.7484Z" fill={fg} />
         <path
           d="M476.252 24.7484L468.527 32.4781V40.2031H476.252V32.4781L484 24.7484V17H476.252V24.7484Z"
-          fill="white"
+          fill={fg}
         />
-        <path d="M484 32.4781L476.252 40.2031H484V32.4781Z" fill="white" />
+        <path d="M484 32.4781L476.252 40.2031H484V32.4781Z" fill={fg} />
       </g>
     </>
   );

--- a/components/badge/Stats/Infomation.tsx
+++ b/components/badge/Stats/Infomation.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 
 export type InfomationProps = {
+  fg: string;
   data: [key: string, value: string][];
 };
 
-const Infomation = ({ data }: InfomationProps) => {
+const Infomation = ({ fg, data }: InfomationProps) => {
   const startY = 83.83;
   const startDelay = 0.5;
   const distance = 24;
@@ -20,7 +21,7 @@ const Infomation = ({ data }: InfomationProps) => {
           }}
         >
           <text
-            fill="white"
+            fill={fg}
             xmlSpace="preserve"
             style={{
               whiteSpace: "nowrap",
@@ -35,7 +36,7 @@ const Infomation = ({ data }: InfomationProps) => {
             </tspan>
           </text>
           <text
-            fill="white"
+            fill={fg}
             xmlSpace="preserve"
             style={{
               whiteSpace: "nowrap",
@@ -50,7 +51,7 @@ const Infomation = ({ data }: InfomationProps) => {
             </tspan>
           </text>
           <text
-            fill="white"
+            fill={fg}
             xmlSpace="preserve"
             style={{
               whiteSpace: "nowrap",

--- a/components/badge/Stats/Stats.tsx
+++ b/components/badge/Stats/Stats.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import fontColorContrast from "font-color-contrast";
 import BlackHole from "./BlackHole";
 import Container from "./Container";
 import Header from "./Header";
@@ -24,18 +25,7 @@ export type StatsProps = {
 
 const Stats = ({ data }: StatsProps) => {
   const height = 190 - (!data.name || !data.email ? 25 : 0);
-  const fgColor = (function() {
-
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(data.color);
-
-    const r = parseInt(result[1], 16);
-    const g = parseInt(result[2], 16);
-    const b = parseInt(result[3], 16);
-
-    const luminance = 1 - (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-    return luminance < 0.5 ? 'black' : 'white';
-  })();
+  const fgColor = fontColorContrast(data.color, 0.7);
 
   return (
     <Container height={height} color={data.color} cover_url={data.cover}>

--- a/components/badge/Stats/Stats.tsx
+++ b/components/badge/Stats/Stats.tsx
@@ -24,10 +24,23 @@ export type StatsProps = {
 
 const Stats = ({ data }: StatsProps) => {
   const height = 190 - (!data.name || !data.email ? 25 : 0);
+  const fgColor = (function() {
+
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(data.color);
+
+    const r = parseInt(result[1], 16);
+    const g = parseInt(result[2], 16);
+    const b = parseInt(result[3], 16);
+
+    const luminance = 1 - (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+    return luminance < 0.5 ? 'black' : 'white';
+  })();
 
   return (
     <Container height={height} color={data.color} cover_url={data.cover}>
       <Header
+        fg={fgColor}
         color={data.color}
         campus={data.campus}
         cursus={data.cursus}
@@ -35,6 +48,7 @@ const Stats = ({ data }: StatsProps) => {
         logo_url={data.logo}
       />
       <Infomation
+        fg={fgColor}
         data={
           [
             ["Grade", data.grade],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@icons-pack/react-simple-icons": "^4.6.1",
     "@prisma/client": "^3.11.0",
     "axios": "^0.26.0",
+    "font-color-contrast": "11.1.0",
     "lodash-es": "^4.17.21",
     "next": "12.1.0",
     "next-auth": "^4.2.1",


### PR DESCRIPTION
I noticed that for coalitions that have a light background color, always using white for the text doesn't create the right contrast.

I decided to implement a simple function in the Stats component that determines which text color should be used based on the brightness of the coalition background color.
